### PR TITLE
AttributeError: 'module' object has no attribute 'PROTOCOL_TLS'

### DIFF
--- a/3rdparty/meross_iot/meross_iot/supported_devices/power_plugs.py
+++ b/3rdparty/meross_iot/meross_iot/supported_devices/power_plugs.py
@@ -125,10 +125,7 @@ class Device:
         self._mqtt_client.on_subscribe = self._on_subscribe
         self._mqtt_client.on_log = self._on_log
         self._mqtt_client.username_pw_set(username=self._user_id, password=hashed_password)
-        self._mqtt_client.tls_set(ca_certs=None, certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED,
-                       tls_version=ssl.PROTOCOL_TLS,
-                       ciphers=None)
-
+        self._mqtt_client.tls_set_context(context=ssl.create_default_context())
         self._mqtt_client.connect(self._domain, self._port, keepalive=30)
         self._set_status(ClientStatus.CONNECTING)
 


### PR DESCRIPTION
J'ai creusé un peu cette erreur suite au problème rencontré suivant : https://github.com/NextDom/plugin-Meross/issues/13

Voici la solution que j'ai trouvé et qui m'a permit d'importer mes prises Meross.

Je me suis basé sur cette documentation : https://www.eclipse.org/paho/clients/python/docs/#option-functions